### PR TITLE
Move compactView option to AccountStorageObject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ dist/
 static/
 /tools/vuicc.exe
 /ui.vuic
+.vscode

--- a/app/constants/AccountStorageKeys.js
+++ b/app/constants/AccountStorageKeys.js
@@ -1,1 +1,1 @@
-export const COMPACT_VIEW = 'compactView'
+export const COMPACT_VIEW = 'compactView';

--- a/app/constants/AccountStorageKeys.js
+++ b/app/constants/AccountStorageKeys.js
@@ -1,0 +1,1 @@
+export const COMPACT_VIEW = 'compactView'

--- a/app/containers/ServerBrowser.js
+++ b/app/containers/ServerBrowser.js
@@ -129,7 +129,7 @@ class ServerBrowser extends Component
 
         let listClassName = 'list-body main-list-body';
 
-        const compactView = this.props.user.accountStorage[AccountStorageKeys.COMPACT_VIEW]
+        const compactView = this.props.user.accountStorage[AccountStorageKeys.COMPACT_VIEW] === 'true'
         if (compactView) {
             listClassName += ' compact';
         }
@@ -323,11 +323,12 @@ const mapDispatchToProps = (dispatch) => {
         },
         toggleCompactView: () => dispatch((innerDispatch, getState) => {
             const key = AccountStorageKeys.COMPACT_VIEW
+            const boolValue = !(getState().user.accountStorage[key] === 'true')
 
             innerDispatch({
                 type: ActionTypes.SET_ACCOUNT_STORAGE_VALUE,
                 key,
-                value: !getState().user.accountStorage[key],
+                value: boolValue.toString(),
             });
         })
     };

--- a/app/containers/ServerBrowser.js
+++ b/app/containers/ServerBrowser.js
@@ -5,6 +5,7 @@ import PerfectScrollbar from 'perfect-scrollbar';
 import * as ServerFetchStatus from '../constants/ServerFetchStatus'
 import * as ServerConnectStatus from '../constants/ServerConnectStatus'
 import * as ActionTypes from '../constants/ActionTypes'
+import * as AccountStorageKeys from '../constants/AccountStorageKeys';
 import * as ServerSort from '../constants/ServerSort'
 import * as SortDirection from '../constants/SortDirection'
 
@@ -22,7 +23,6 @@ class ServerBrowser extends Component
         this.state = {
             expandedServer: null,
             filtersVisible: false,
-            compactView: false,
             width: 920,
             height: 580,
         };
@@ -129,7 +129,8 @@ class ServerBrowser extends Component
 
         let listClassName = 'list-body main-list-body';
 
-        if (this.state.compactView) {
+        const compactView = this.props.user.accountStorage[AccountStorageKeys.COMPACT_VIEW]
+        if (compactView) {
             listClassName += ' compact';
         }
 
@@ -151,9 +152,9 @@ class ServerBrowser extends Component
                                 <a href="#" onClick={this.onEditFilters.bind(this)}><i className="material-icons">filter_list</i></a>
                                 <ServerFilters visible={this.state.filtersVisible} onClose={this._onCloseFilters} />
                             </div>
-                            <div className={"header-action compact" + (this.state.compactView ? ' active' : '')}>
+                            <div className={"header-action compact" + (compactView ? ' active' : '')}>
                                 <span>Compact view</span>
-                                <a href="#" onClick={this.onToggleCompactView.bind(this)}><i className="material-icons">{this.state.compactView ? 'toggle_on' : 'toggle_off'}</i></a>
+                                <a href="#" onClick={this.onToggleCompactView.bind(this)}><i className="material-icons">{compactView ? 'toggle_on' : 'toggle_off'}</i></a>
                             </div>
                         </div>
                         <div className="column column-2" onClick={this._onSortByMap}>
@@ -211,7 +212,7 @@ class ServerBrowser extends Component
         if (e)
             e.preventDefault();
 
-        this.setState({ compactView: !this.state.compactView });
+        this.props.toggleCompactView();
     }
 
     _onExpandServer = (guid) =>
@@ -292,7 +293,8 @@ class ServerBrowser extends Component
 const mapStateToProps = (state) => {
     return {
         base: state.base,
-        servers: state.servers
+        servers: state.servers,
+        user: state.user,
     };
 };
 
@@ -318,7 +320,16 @@ const mapDispatchToProps = (dispatch) => {
         },
         cycleServerSortDirection: () => {
             dispatch({ type: ActionTypes.CYCLE_SERVER_SORT_DIRECTION })
-        }
+        },
+        toggleCompactView: () => dispatch((innerDispatch, getState) => {
+            const key = AccountStorageKeys.COMPACT_VIEW
+
+            innerDispatch({
+                type: ActionTypes.SET_ACCOUNT_STORAGE_VALUE,
+                key,
+                value: !getState().user.accountStorage[key],
+            });
+        })
     };
 };
 

--- a/app/containers/ServerBrowser.js
+++ b/app/containers/ServerBrowser.js
@@ -129,7 +129,7 @@ class ServerBrowser extends Component
 
         let listClassName = 'list-body main-list-body';
 
-        const compactView = this.props.user.accountStorage[AccountStorageKeys.COMPACT_VIEW] === 'true'
+        const compactView = this.props.user.accountStorage[AccountStorageKeys.COMPACT_VIEW] === 'true';
         if (compactView) {
             listClassName += ' compact';
         }

--- a/app/containers/ServerBrowser.js
+++ b/app/containers/ServerBrowser.js
@@ -322,8 +322,8 @@ const mapDispatchToProps = (dispatch) => {
             dispatch({ type: ActionTypes.CYCLE_SERVER_SORT_DIRECTION })
         },
         toggleCompactView: () => dispatch((innerDispatch, getState) => {
-            const key = AccountStorageKeys.COMPACT_VIEW
-            const boolValue = !(getState().user.accountStorage[key] === 'true')
+            const key = AccountStorageKeys.COMPACT_VIEW;
+            const boolValue = !(getState().user.accountStorage[key] === 'true');
 
             innerDispatch({
                 type: ActionTypes.SET_ACCOUNT_STORAGE_VALUE,

--- a/app/index.js
+++ b/app/index.js
@@ -2,7 +2,7 @@ import 'react-hot-loader'
 import React from 'react'
 import { render } from 'react-dom'
 import { applyMiddleware, createStore } from 'redux'
-import thunk from 'redux-thunk';
+import thunk from 'redux-thunk'
 import { Provider } from 'react-redux'
 import { hashHistory } from 'react-router'
 

--- a/app/index.js
+++ b/app/index.js
@@ -1,7 +1,8 @@
 import 'react-hot-loader'
 import React from 'react'
 import { render } from 'react-dom'
-import { createStore } from 'redux'
+import { applyMiddleware, createStore } from 'redux'
+import thunk from 'redux-thunk';
 import { Provider } from 'react-redux'
 import { hashHistory } from 'react-router'
 
@@ -41,7 +42,7 @@ window.updateState = UpdateState;
 window.updateError = UpdateError;
 
 // Create the main application store.
-let store = createStore(reducer);
+let store = createStore(reducer, applyMiddleware(thunk));
 
 const fetchNews = () => new Promise((resolve, reject) => {
     fetch('https://veniceunleashed.net/vu-ig-news')

--- a/app/reducers/user.js
+++ b/app/reducers/user.js
@@ -18,6 +18,7 @@ import * as LoginStatus from '../constants/LoginStatus'
 import * as PlayerLoginStatus from '../constants/PlayerLoginStatus'
 import * as OriginLinkStatus from '../constants/OriginLinkStatus'
 import * as ConnectionStatus from '../constants/ConnectionStatus'
+import * as AccountStorageKeys from '../constants/AccountStorageKeys'
 
 import { hashHistory } from 'react-router'
 
@@ -31,7 +32,9 @@ const initialState = {
     playerLoginStatus: 0,
     originLinkStatus: 0,
     loginToken: null,
-    accountStorage: {},
+    accountStorage: {
+        [AccountStorageKeys.COMPACT_VIEW]: false,
+    },
 };
 
 function createStateCopy(state)

--- a/app/reducers/user.js
+++ b/app/reducers/user.js
@@ -33,7 +33,7 @@ const initialState = {
     originLinkStatus: 0,
     loginToken: null,
     accountStorage: {
-        [AccountStorageKeys.COMPACT_VIEW]: false,
+        [AccountStorageKeys.COMPACT_VIEW]: 'false',
     },
 };
 

--- a/app/reducers/user.js
+++ b/app/reducers/user.js
@@ -18,7 +18,6 @@ import * as LoginStatus from '../constants/LoginStatus'
 import * as PlayerLoginStatus from '../constants/PlayerLoginStatus'
 import * as OriginLinkStatus from '../constants/OriginLinkStatus'
 import * as ConnectionStatus from '../constants/ConnectionStatus'
-import * as AccountStorageKeys from '../constants/AccountStorageKeys'
 
 import { hashHistory } from 'react-router'
 
@@ -32,9 +31,7 @@ const initialState = {
     playerLoginStatus: 0,
     originLinkStatus: 0,
     loginToken: null,
-    accountStorage: {
-        [AccountStorageKeys.COMPACT_VIEW]: 'false',
-    },
+    accountStorage: {},
 };
 
 function createStateCopy(state)


### PR DESCRIPTION
This PR can act as an opportunity for discussion about how account object storage should be used.

I have some questions

1. How the accountStorage state is hydrated? Are you doing it from VU side?
2. Should we always update the accountStorage through the SET_ACCOUNT_STORAGE_VALUE or we are free to use the web call in another reducers?
3. Should the values in accountStorage all be strings (i use boolean now) and manually parse them when its time to be used in components?