### PR TITLE
Display server tags sorted

### DIFF
--- a/app/components/ServerFilters.js
+++ b/app/components/ServerFilters.js
@@ -198,6 +198,8 @@ class ServerFilters extends Component
         for (const tag of tagSet)
             tagOptions.push({ value: tag, label: tag });
 
+        tagOptions.sort((a, b) => a.value.localeCompare(b.value));
+
         const selectedTags = [];
 
         for (const tag of this.state.tags)


### PR DESCRIPTION
I noticed that the tags aren't sorted and found it a bit annoying 😄 

after fix:
![image](https://user-images.githubusercontent.com/1511946/179418870-c512ca53-d223-436b-9891-d0b8dff3cdfc.png)
