### PR TITLE
fix missing password popup

### DIFF
--- a/app/components/ServerEntry.js
+++ b/app/components/ServerEntry.js
@@ -109,6 +109,24 @@ class ServerEntry extends Component
         ) !== null)
             return;
 
+        let fps = null;
+
+        if ('fps' in this.props.server.variables) {
+            fps = parseInt(this.props.server.variables.fps, 10);
+
+            if (isNaN(fps)) {
+                fps = null;
+            }
+        }
+
+        if ((this.props.server.variables.frequency === 'high60' && fps !== null && fps <= 66) ||
+            (this.props.server.variables.frequency === 'high120' && fps !== null && fps <= 132) ||
+            (this.props.server.variables.frequency === 'reg' && fps !== null && fps <= 33))
+        {
+            this.props.setPopup(<ServerPerformancePopup server={this.props.server} onJoin={this.props.onSpectate} />);
+            return;
+        }
+
         if (this.props.server.passworded)
         {
             this.props.setPopup(<ServerPasswordPopup server={this.props.server} onJoin={this.props.onSpectate} />);

--- a/app/popups/ServerPerformancePopup.js
+++ b/app/popups/ServerPerformancePopup.js
@@ -62,6 +62,9 @@ const mapDispatchToProps = (dispatch) => {
     return {
         closePopup: () => {
             dispatch({ type: ActionTypes.SET_POPUP, popup: null })
+        },
+        setPopup: (popup) => {
+            dispatch({ type: ActionTypes.SET_POPUP, popup: popup })
         }
     };
 };

--- a/app/test.js
+++ b/app/test.js
@@ -453,6 +453,27 @@ DispatchAction(actions.SET_SERVERS, {
                 vext_req: "1.2.3",
             }
         },
+        {
+            guid: "N9",
+            name: "Explorer 99",
+            players: 12,
+            maxplayers: 128,
+            public: true,
+            passworded: true,
+            ping: 123,
+            variables: {
+                maxplayers: 128,
+                mapname: "Levels/XP3_Desert/XP3_Desert",
+                gamemode: "ConquestLarge0",
+                frequency: "reg",
+                maxspectators: 12,
+                spectators: "0",
+                buildno: "12345",
+                min_buildno: "12345",
+                vext_req: "1.2.3",
+                fps: 30
+            }
+        },
     ]
 });
 


### PR DESCRIPTION
fix missing password popup when the server has performance issues. Before it would just close the performance popup instead of showing the password popup.

Also added the performance popup when joining as spectator as well cuz that was missing there.