### PR TITLE
Remove brightness filter from VU watermark

### DIFF
--- a/src/styles/screen.scss
+++ b/src/styles/screen.scss
@@ -128,7 +128,6 @@ a {
     z-index: 99999;
     opacity: 0.3;
     text-align: center;
-    filter: brightness(6);
 
     img {
         height: 50rem; // 50px


### PR DESCRIPTION
This brightness filter was added because the VU watermark wasn’t visible otherwise. This is no-longer the case now that the blending mode is fixed